### PR TITLE
Address dependabot alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem 'omniauth-rails_csrf_protection', '~> 1.0'
 gem 'omniauth-twitter', '~> 1.4'
 
 # For two-factor authentication
-gem 'devise-two-factor', '~> 5.0'
+gem 'devise-two-factor', '~> 6.0'
 gem 'rqrcode', '~> 2.2'
 
 # For SMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,10 +146,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise-two-factor (5.1.0)
-      activesupport (~> 7.0)
+    devise-two-factor (6.1.0)
+      activesupport (>= 7.0, < 8.1)
       devise (~> 4.0)
-      railties (~> 7.0)
+      railties (>= 7.0, < 8.1)
       rotp (~> 6.0)
     devise_invitable (2.0.9)
       actionmailer (>= 5.0)
@@ -483,7 +483,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise (~> 4.9)
-  devise-two-factor (~> 5.0)
+  devise-two-factor (~> 6.0)
   devise_invitable (~> 2.0)
   devise_masquerade (~> 2.1)
   dotenv-rails (~> 2.8, >= 2.8.1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades `devise-two-factor` from `~>5.0` to `~>6.0` (locked to `6.1.0`) and updates related lockfile constraints.
> 
> - **Dependencies**:
>   - Upgrade `devise-two-factor` from `~>5.0` to `~>6.0`.
>     - Lockfile updates: `devise-two-factor` to `6.1.0` with updated `activesupport` and `railties` version bounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32b310b71e3f6505c798d728eeca6c8ddce13da5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->